### PR TITLE
Fix duplicated resource spending

### DIFF
--- a/Source/Plugin_Development/ResourceManagementSystem/ResourceSystemComponent.cpp
+++ b/Source/Plugin_Development/ResourceManagementSystem/ResourceSystemComponent.cpp
@@ -64,7 +64,10 @@ void UResourceSystemComponent::SpendResource(FName ResourceName, int32 Amount)
     {
         GetWorldSubsystem()->SpendResource(this, ResourceName, Amount);
     }
-    Server_SpendResource(ResourceName, Amount);
+    else
+    {
+        Server_SpendResource(ResourceName, Amount);
+    }
 }
 
 int32 UResourceSystemComponent::GetResource(FName ResourceName) const


### PR DESCRIPTION
## Summary
- fix `SpendResource` to avoid double spending when called on the server

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c57d70aa88332a6ce1a30f78c5cf0