### PR TITLE
Unified upgrade definition folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A modular framework for prototyping, testing, and packaging Unreal Engine gamepl
 A data‑driven upgrade framework that lets any actor gain leveling, ranking, or tiered progression:
 
 * **Component + Subsystem**: drop `UUpgradableComponent` onto actors; `UUpgradeManagerSubsystem` handles level state, validation, and timers.
-* **Flexible Data Providers**: choose JSON, DataTable folder, or DataAsset folder in project settings.
+* **Flexible Data Providers**: drop JSON files, DataTables or DataAssets into a single folder and the subsystem will autodetect them.
 * **Dynamic Resource Interning**: at runtime, any `FName` resource type is interned into a shared array for minimal memory and fast lookups.
 * **Enum‑driven**: extend `EUpgradableAspect` to add your custom upgrade progression types (e.g. Level, Tier, Rank). Extend `EUpgradableCategopry` e.g. Unit, Building, Equipment.
 * **Blueprint & C++ API**: high‑level calls such as `RequestUpgradeForActor`, `GetUpgradeLevelForActor`, or batch queries by aspect or path.
@@ -36,11 +36,11 @@ A data‑driven upgrade framework that lets any actor gain leveling, ranking, or
 
 ## Configuration
 
-Open **Project Settings → Upgrade System Settings** to select your data source and containing folder.
+Open **Project Settings → Upgrade System Settings** and set the single folder that contains your upgrade definition files.
 
 1. **JSON files**: each file defines an `UpgradePath` (e.g. BasicUnit, AdvancedBuilding, Ring) and a `levels` array with resource costs, upgrade durations, and locked status. Field names can be customized in the **Json Field Names** section of the settings if your JSON schema uses different names.
 2. **DataTables**: `UpgradePath` should be the table's name and each row struct (`FUpgradeDefinition`) represents one level.
-3. **DataAssets**: Defines `UpgradePath` and `TArray<FUpgradeDefinition>`
+3. **DataAssets**: Defines `UpgradePath` and `TArray<FUpgradeDefinition>`.
 4. **DataAsset**: `UOnLevelUpVisualsDataAsset` bundles meshes, materials, and niagara systems that can be applied through `UUpgradableComponent::ChangeActorVisualsPerUpgradeLevel` in BP to change the visual appearance of an actor as it levels up.
 
 Upgrade data definitions populate the central catalog (`UpgradePathId → TArray<FUpgradeDefinition>`) and the resource name table.

--- a/Source/Plugin_Development/Plugin_Development.Build.cs
+++ b/Source/Plugin_Development/Plugin_Development.Build.cs
@@ -8,6 +8,6 @@ public class Plugin_Development : ModuleRules
 	{
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 
-		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "Json", "JsonUtilities", "Niagara", "DeveloperSettings", "UMG" });
+                PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput", "Json", "JsonUtilities", "Niagara", "DeveloperSettings", "UMG", "AssetRegistry" });
 	}
 }

--- a/Source/Plugin_Development/UpgradableManagementSystem/UpgradeManagerSubsystem.h
+++ b/Source/Plugin_Development/UpgradableManagementSystem/UpgradeManagerSubsystem.h
@@ -23,7 +23,7 @@ public:
 	virtual void Deinitialize() override;
 	virtual void OnWorldBeginPlay(UWorld& InWorld) override;
 	
-	void InitializeProvider();
+       void InitializeProviders();
 	int32 RegisterUpgradableComponent(UUpgradableComponent* Component);
 	void UnregisterUpgradableComponent(int32 ComponentId);
 	
@@ -178,8 +178,8 @@ protected:
 	UPROPERTY()
 	FString UpgradeDataFolderPath;
 
-	UPROPERTY()
-	TObjectPtr<UUpgradeDataProvider> DataProvider;
+       UPROPERTY()
+       TArray<TObjectPtr<UUpgradeDataProvider>> DataProviders;
 
 	// Loaders
 	void LoadCatalog();

--- a/Source/Plugin_Development/UpgradableManagementSystem/UpgradeSettings.h
+++ b/Source/Plugin_Development/UpgradableManagementSystem/UpgradeSettings.h
@@ -3,13 +3,6 @@
 #include "Engine/DeveloperSettings.h"
 #include "UpgradeSettings.generated.h"
 
-UENUM(BlueprintType)
-enum class EUpgradeCatalogSource : uint8
-{
-	JsonFolder  UMETA(DisplayName = "JSON Folder"),
-	DataTableFolder      UMETA(DisplayName = "Data Table Folder"),
-        DataAssetFolder UMETA(DisplayName = "Data Asset Folder")
-};
 
 USTRUCT(BlueprintType)
 struct PLUGIN_DEVELOPMENT_API FUpgradeJsonFieldNames
@@ -44,23 +37,12 @@ class UUpgradeSettings : public UDeveloperSettings
 	GENERATED_BODY()
 
 public:
-	// Select catalog source
-	UPROPERTY(EditAnywhere, config, Category="Upgrade Catalog")
-	EUpgradeCatalogSource CatalogSource = EUpgradeCatalogSource::JsonFolder;
-
-	// Directory path under Content/ for JSON files
-	UPROPERTY(EditAnywhere, config, Category="Upgrade Catalog", meta=(EditCondition="CatalogSource==EUpgradeCatalogSource::JsonFolder"))
-	FString JsonFolderPath = TEXT("Data/UpgradeJSONs");
-
-	// Directory path for DataTables: include /Game/...
-	UPROPERTY(EditAnywhere, config, Category="Upgrade Catalog", meta=(EditCondition="CatalogSource==EUpgradeCatalogSource::DataTableFolder"))
-	FString DataTableFolderPath = TEXT("/Game/Data/UpgradeDataTables");
-
-       // Directory path for DataAssets: include /Game/...
-       UPROPERTY(EditAnywhere, config, Category="Upgrade Catalog", meta=(EditCondition="CatalogSource==EUpgradeCatalogSource::DataAssetFolder"))
-       FString DataAssetFolderPath = TEXT("/Game/Data/UpgradeDataAssets");
+       // Folder containing upgrade definition files of any supported type
+       // For assets this should be an "/Game/..." path. JSON files will be loaded from the corresponding directory on disk.
+       UPROPERTY(EditAnywhere, config, Category="Upgrade Catalog")
+       FString UpgradeDataFolderPath = TEXT("/Game/Data/UpgradeDefinitions");
 
        // Custom JSON field names if your files use different keys
-       UPROPERTY(EditAnywhere, config, Category="Upgrade Catalog", meta=(EditCondition="CatalogSource==EUpgradeCatalogSource::JsonFolder"))
+       UPROPERTY(EditAnywhere, config, Category="Upgrade Catalog")
        FUpgradeJsonFieldNames JsonFieldNames;
 };


### PR DESCRIPTION
## Summary
- use a single upgrade data folder path in project settings
- auto-detect which data providers are required and initialize them using maps
- update subsystem implementation to scan JSON, data table and data asset types
- document the new workflow
- add AssetRegistry to plugin build dependencies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d6c6a70208332bdec4e392384c31c