### PR TITLE
Add extensible file scanning for upgrade providers

### DIFF
--- a/Source/Plugin_Development/UpgradableManagementSystem/UpgradeDataProvider.h
+++ b/Source/Plugin_Development/UpgradableManagementSystem/UpgradeDataProvider.h
@@ -22,7 +22,7 @@ public:
 
     // Currently supported Data Tables and Data Assets
     virtual void ScanForAssets(const FString& FolderPath, TArray<UUpgradeDataProvider*>& Providers);
-    // Currently supported JSON
+    // Currently supported files (e.g. JSON). Extend ExtensionToProvider map in ScanForFiles to support more types.
     virtual void ScanForFiles(const FString& FolderPath, TArray<UUpgradeDataProvider*>& Providers);
 
     /**


### PR DESCRIPTION
## Summary
- make file scanning extensible through an extension-to-provider map
- include missing headers for file scanning utilities

## Testing
- `./run_tests.sh` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ecb2bd72c8332a37487c08cdbf90d