### PR TITLE
Fix UI component binding and initial resource population

### DIFF
--- a/Source/Plugin_Development/ResourceManagementSystem/ResourceDisplayWidget.cpp
+++ b/Source/Plugin_Development/ResourceManagementSystem/ResourceDisplayWidget.cpp
@@ -32,23 +32,18 @@ void UResourceDisplayWidget::BuildResourceEntries()
     ResourceListBox->ClearChildren();
     ResourceEntries.Empty();
 
-    if (UWorld* World = GetWorld())
+    TMap<FName, int32> AllResources;
+    ResourceComp->GetAllResources(AllResources);
+
+    for (auto& Pair : AllResources)
     {
-        if (UResourceManagerSubsystem* Sub = World->GetSubsystem<UResourceManagerSubsystem>())
+        UTextBlock* Entry = WidgetTree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass());
+        if (Entry)
         {
-            TMap<FName, int32> AllResources;
-            Sub->GetAllResources(ResourceComp, AllResources);
-            for (auto& Pair : AllResources)
-            {
-                UTextBlock* Entry = WidgetTree->ConstructWidget<UTextBlock>(UTextBlock::StaticClass());
-                if (Entry)
-                {
-                    FString EntryText = FString::Printf(TEXT("%s: %d"), *Pair.Key.ToString(), Pair.Value);
-                    Entry->SetText(FText::FromString(EntryText));
-                    ResourceListBox->AddChild(Entry);
-                    ResourceEntries.Add(Pair.Key, Entry);
-                }
-            }
+            FString EntryText = FString::Printf(TEXT("%s: %d"), *Pair.Key.ToString(), Pair.Value);
+            Entry->SetText(FText::FromString(EntryText));
+            ResourceListBox->AddChild(Entry);
+            ResourceEntries.Add(Pair.Key, Entry);
         }
     }
 }

--- a/Source/Plugin_Development/ResourceManagementSystem/ResourceDisplayWidget.h
+++ b/Source/Plugin_Development/ResourceManagementSystem/ResourceDisplayWidget.h
@@ -9,7 +9,6 @@
 
 class UVerticalBox;
 class UTextBlock;
-class UResourceComponent;
 
 /**
  * 

--- a/Source/Plugin_Development/UpgradableManagementSystem/UpgradeTimerDisplay.cpp
+++ b/Source/Plugin_Development/UpgradableManagementSystem/UpgradeTimerDisplay.cpp
@@ -21,16 +21,20 @@ void UUpgradeTimerDisplay::NativeConstruct()
 
 void UUpgradeTimerDisplay::BindUpgradableComponent(int32 ComponentId)
 {
-	if (!TrackedComponent) return;
-	
-	if (UUpgradableComponent* Comp = GetWorld()->GetSubsystem<UUpgradeManagerSubsystem>()->GetComponentById(ComponentId))
-	{
-		TrackedComponent = Comp;
-		TrackedComponent->OnUpgradeStarted.AddDynamic(this, &UUpgradeTimerDisplay::HandleUpgradeStarted);
-		TrackedComponent->OnUpgradeCanceled.AddDynamic(this, &UUpgradeTimerDisplay::HandleUpgradeCanceled);
-		TrackedComponent->OnLevelChanged.AddDynamic(this, &UUpgradeTimerDisplay::HandleLevelChanged);
-		TrackedComponent->OnTimeToUpgradeChanged.AddDynamic(this, &UUpgradeTimerDisplay::HandleTimeToUpgradeChanged);
-	}
+        // Only early-out if we're already tracking a component
+        if (TrackedComponent)
+        {
+                return;
+        }
+
+        if (UUpgradableComponent* Comp = GetWorld()->GetSubsystem<UUpgradeManagerSubsystem>()->GetComponentById(ComponentId))
+        {
+                TrackedComponent = Comp;
+                TrackedComponent->OnUpgradeStarted.AddDynamic(this, &UUpgradeTimerDisplay::HandleUpgradeStarted);
+                TrackedComponent->OnUpgradeCanceled.AddDynamic(this, &UUpgradeTimerDisplay::HandleUpgradeCanceled);
+                TrackedComponent->OnLevelChanged.AddDynamic(this, &UUpgradeTimerDisplay::HandleLevelChanged);
+                TrackedComponent->OnTimeToUpgradeChanged.AddDynamic(this, &UUpgradeTimerDisplay::HandleTimeToUpgradeChanged);
+        }
 }
 
 void UUpgradeTimerDisplay::HandleUpgradeStarted_Implementation(float SecondsUntilCompleted)


### PR DESCRIPTION
## Summary
- remove unused forward declaration for `UResourceComponent`
- populate `ResourceDisplayWidget` directly from `UResourceSystemComponent`
- allow `UpgradeTimerDisplay` to bind when `TrackedComponent` is null

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684ed098745c83328f508a2e1142818c