### PR TITLE
Handle duplicate upgrade paths

### DIFF
--- a/Source/Plugin_Development/UpgradableManagementSystem/UpgradeDataAssetProvider.cpp
+++ b/Source/Plugin_Development/UpgradableManagementSystem/UpgradeDataAssetProvider.cpp
@@ -36,6 +36,15 @@ void UUpgradeDataAssetProvider::InitializeData(TMap<FName, TArray<FUpgradeDefini
         
         // Fallback to asset name if no UpgradePathId is set
         FName PathId = !Asset->UpgradePathId.IsNone() ? Asset->UpgradePathId : AssetData.AssetName;
+
+        TArray<FUpgradeDefinition>* ExistingArray = OutCatalog.Find(PathId);
+        if (ExistingArray)
+        {
+            UE_LOG(LogTemp, Warning, TEXT("[UPGRADECATALOG_WARN_01] Duplicate UpgradePath '%s' found in asset '%s'. Overriding previous data."),
+                   *PathId.ToString(), *AssetData.AssetName.ToString());
+            ExistingArray->Reset();
+        }
+
         TArray<FUpgradeDefinition>& LevelDataArray = OutCatalog.FindOrAdd(PathId);
 
         int32 ProcessedLevels = 0;

--- a/Source/Plugin_Development/UpgradableManagementSystem/UpgradeDataTableProvider.cpp
+++ b/Source/Plugin_Development/UpgradableManagementSystem/UpgradeDataTableProvider.cpp
@@ -34,6 +34,15 @@ void UUpgradeDataTableProvider::InitializeData(TMap<FName, TArray<FUpgradeDefini
         ++LoadedTables;
 
         FName PathId = FName(*Table->GetName());
+
+        TArray<FUpgradeDefinition>* ExistingArray = OutCatalog.Find(PathId);
+        if (ExistingArray)
+        {
+            UE_LOG(LogTemp, Warning, TEXT("[UPGRADECATALOG_WARN_01] Duplicate UpgradePath '%s' found in DataTable '%s'. Overriding previous data."),
+                   *PathId.ToString(), *Table->GetName());
+            ExistingArray->Reset();
+        }
+
         TArray<FUpgradeDefinition>& LevelArray = OutCatalog.FindOrAdd(PathId);
         
         int32 ProcessedRows = 0;

--- a/Source/Plugin_Development/UpgradableManagementSystem/UpgradeJsonProvider.cpp
+++ b/Source/Plugin_Development/UpgradableManagementSystem/UpgradeJsonProvider.cpp
@@ -50,7 +50,15 @@ void UUpgradeJsonProvider::InitializeData(TMap<FName, TArray<FUpgradeDefinition>
                         PathId = FName(*FPaths::GetBaseFilename(File));
                         UE_LOG(LogTemp, Verbose, TEXT("[UPGRADEJSON_INFO_02] Using filename '%s' as UpgradePathId for file: %s"), *PathId.ToString(), *File);
                 }
-		TArray<FUpgradeDefinition>& LevelDataArray = OutCatalog.FindOrAdd(PathId);
+                TArray<FUpgradeDefinition>* ExistingArray = OutCatalog.Find(PathId);
+                if (ExistingArray)
+                {
+                        UE_LOG(LogTemp, Warning, TEXT("[UPGRADECATALOG_WARN_01] Duplicate UpgradePath '%s' found in JSON file '%s'. Overriding previous data."),
+                               *PathId.ToString(), *FPaths::GetCleanFilename(File));
+                        ExistingArray->Reset();
+                }
+
+                TArray<FUpgradeDefinition>& LevelDataArray = OutCatalog.FindOrAdd(PathId);
 
 		// Extract levels array
 		const TArray<TSharedPtr<FJsonValue>>* Levels;


### PR DESCRIPTION
## Summary
- detect duplicate UpgradePath entries during catalog load
- log a warning and override previous levels when duplicates appear

## Testing
- `echo 'No tests defined'`

------
https://chatgpt.com/codex/tasks/task_e_684ed3cef4148332a75fb760e0bdd479