### PR TITLE
Refine scaling segment parsing

### DIFF
--- a/Source/Plugin_Development/UpgradableManagementSystem/UpgradeJsonProvider.h
+++ b/Source/Plugin_Development/UpgradableManagementSystem/UpgradeJsonProvider.h
@@ -6,10 +6,14 @@
 
 UCLASS()
 class PLUGIN_DEVELOPMENT_API UUpgradeJsonProvider : public UUpgradeDataProvider
-{
-        GENERATED_BODY()
-public:
-       UUpgradeJsonProvider();
-       virtual void InitializeData(TMap<FName, TArray<FUpgradeDefinition>>& OutCatalog,
-                                   TArray<FName>& OutResourceTypes) override;
+	{
+	GENERATED_BODY()
+
+	public:
+	UUpgradeJsonProvider();
+	virtual void InitializeData(TMap<FName, TArray<FUpgradeDefinition>>& OutCatalog,
+	TArray<FName>& OutResourceTypes) override;
+	
+	private:
+	bool ParseScalingSegment(const TSharedPtr<FJsonObject>& JsonObject, FRequirementsScalingSegment& OutSegment) const;
 };


### PR DESCRIPTION
## Summary
- update `ParseScalingSegment` to parse fields based on selected scaling mode
- keep calls to the helper where segments are parsed

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_687782181a7883329c1143f3ed5309e4